### PR TITLE
Add working base without complete Weave networking support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,27 @@
+language: go
+
+# Needed, or go imports will use code from 'Spirals-Team/docker-g5k' when building a fork
+go_import_path: github.com/Spirals-Team/docker-g5k
+
+env:
+    - GIMME_OS=linux GIMME_ARCH=amd64
+    - GIMME_OS=darwin GIMME_ARCH=amd64
+    - GIMME_OS=windows GIMME_ARCH=amd64
+
+install:
+    - go get -d -v ./...
+
+script:
+    - go test ./...
+    - go build -v -o docker-g5k-$GIMME_OS-$GIMME_ARCH
+
+deploy:
+    provider: releases
+    skip_cleanup: true
+    file: "docker-g5k-$GIMME_OS-$GIMME_ARCH"
+
+    on:
+        tags: true
+    
+    api_key:
+        secure: Dbz7sdvLuyPFThLoTZCf3SeTTAxJgXWQ3q8Jdz4KEBJtPJQH1Q+9c7nEq/A2iI2GLvyMzntSB7BqCz8+XxIRTa1WwSkWIFC81KDnjS6Y2QtKzsn2SXprKDDkueK+9H5hsTjM6sw9CWgb5y8vWTF6ZeCW0wViUm4Sz8XzDGa4mcvCL6om6SWuKgHmfFBgj1qkhrrOzistxYDZHM6UjEAw8XYlZ0Q1peRleHZ+JbFyArkVak5XOOt6EtOCfztad9uNgWWqnfGoSDs+hE9++NVy5AO7jhzwln4scIsSjntnrjlgTSBGCH9WyhnuwTbY3Z0IcO3sQa6cKi5FNiVKFT27fj7nsh4fuqMW894Fq/dOS+fKuwzQnqZAtJvzPjoy1rDqmP19D1UfMelI+l7Qb7XRoYqt7oGgEiZQp6xJx9U3g45iKQibLBaL/Quhqc/a94YLdskoZ54JbuaNoKGimESvmAua8oRbIc9hg9Fh9XfSWdgw7ZP8Ivz18G+r5W6JnqpTlgjC6k/2PIqXuHO0Ll2ryeQL7T803OPThMSS0CDgKsxDH27tiFsKLMsdnYb8SUgA82NaMIAL3RKWGWbegFWlfPobebhKyM4YDt6Q88VRWgZ6RTfU+TbTg47Xoljx2W6RUEtOj1W8SBYeFNE17VJlsEYslQrmSJsFte9x80/mIas=

--- a/README.md
+++ b/README.md
@@ -1,2 +1,105 @@
 # docker-g5k
 Docker Grid5000 client (CLI and Go library)
+
+## Requirements
+* [Docker](https://www.docker.com/products/overview#/install_the_platform)
+* [Docker Machine](https://docs.docker.com/machine/install-machine)
+* [Docker Machine Driver for Grid5000](https://github.com/Spirals-Team/docker-machine-driver-g5k)
+* [Go tools](https://golang.org/doc/install)
+
+You need a Grid5000 account to use this tool. See [this page](https://www.grid5000.fr/mediawiki/index.php/Grid5000:Get_an_account) to create an account.
+
+## Installation
+
+## Installation from sources
+*This procedure was only tested on Ubuntu 16.04.*
+
+To use the Go tools, you need to set your [GOPATH](https://golang.org/doc/code.html#GOPATH) variable environment.
+
+To get the code and compile the binary, run:
+```bash
+go get -u github.com/Spirals-Team/docker-g5k
+```
+
+Then, either put the 'docker-g5k' binary in a directory filled in your PATH environment variable, or run:
+```bash
+export PATH=$PATH:$GOPATH/bin
+```
+
+## How to use
+
+### VPN
+You need to be connected to the Grid5000 VPN to create and access your Docker nodes.  
+Do not forget to configure your DNS or use OpenVPN DNS auto-configuration.  
+Please follow the instructions from the [Grid5000 Wiki](https://www.grid5000.fr/mediawiki/index.php/VPN).
+
+### Driver-specific options
+
+#### Global options
+
+|            Option            |                       Description                       |     Default value     |  Required  |
+|------------------------------|---------------------------------------------------------|-----------------------|------------|
+| `--g5k-username`             | Your Grid5000 account username                          |                       | Yes        |
+| `--g5k-password`             | Your Grid5000 account password                          |                       | Yes        |
+| `--g5k-site`                 | Site to reserve the resources on                        |                       | Yes        |
+
+#### Cluster creation options
+
+|            Option            |                       Description                       |     Default value     |  Required  |
+|------------------------------|---------------------------------------------------------|-----------------------|------------|
+| `--swarm-discovery-token`    | Discovery token to use for joining a Swarm cluster      |                       | Yes        |
+| `--g5k-nb-nodes`             | Number of nodes to allocate                             | 3                     | No         |
+| `--g5k-walltime`             | Timelife of the machine                                 | "1:00:00"             | No         |
+| `--g5k-ssh-private-key`      | Path of your ssh private key                            | "~/.ssh/id_rsa"       | No         |
+| `--g5k-ssh-public-key`       | Path of your ssh public key                             | "< private-key >.pub" | No         |
+| `--g5k-image`                | Name of the image to deploy                             | "jessie-x64-min"      | No         |
+| `--g5k-resource-properties`  | Resource selection with OAR properties (SQL format)     |                       | No         |
+
+#### Cluster deletion options
+
+|            Option            |                       Description                       |     Default value     |  Required  |
+|------------------------------|---------------------------------------------------------|-----------------------|------------|
+| `--g5k-job-id`               | Only remove nodes related to the provided job ID        |                       | No         |
+
+### Examples
+
+#### Cluster creation
+
+An example of a 3 nodes Docker Swarm cluster creation:
+```bash
+docker-g5k --g5k-username user \
+--g5k-password ******** \
+--g5k-site lille \
+create-cluster \
+--g5k-ssh-private-key ~/.ssh/g5k-key
+```
+
+An example of a 16 nodes Docker Swarm cluster creation with resource properties (nodes in cluster `chimint` with more thant 8GB of RAM and at least 4 CPU cores):
+```bash
+docker-g5k --g5k-username user \
+--g5k-password ******** \
+--g5k-site lille \
+create-cluster \
+--g5k-ssh-private-key ~/.ssh/g5k-key \
+--g5k-nb-nodes 16 \
+--g5k-resource-properties "cluster = 'chimint' and memnode > 8192 and cpucore >= 4"
+```
+
+#### Cluster deletion
+
+An example of deleting all provisionned nodes:
+```bash
+docker-g5k --g5k-username user \
+--g5k-password ******** \
+--g5k-site lille \
+remove-cluster
+```
+
+An example of deleting only nodes related to a job ID:
+```bash
+docker-g5k --g5k-username user \
+--g5k-password ******** \
+--g5k-site lille \
+remove-cluster \
+--g5k-job-id 1234567
+```

--- a/README.md
+++ b/README.md
@@ -48,18 +48,18 @@ Please follow the instructions from the [Grid5000 Wiki](https://www.grid5000.fr/
 
 |            Option            |                       Description                       |     Default value     |  Required  |
 |------------------------------|---------------------------------------------------------|-----------------------|------------|
-| `--swarm-discovery`          | Discovery service to use with Swarm                     |                       | Yes        |
-| `--swarm-image`              | Specify Docker image to use for Swarm                   | "swarm:latest"        | No         |
-| `--swarm-strategy`           | Define a default scheduling strategy for Swarm          | "spread"              | No         |
-| `--swarm-opt`                | Define arbitrary flags for Swarm master                 |                       | No         |
-| `--swarm-join-opt`           | Define arbitrary flags for Swarm join                   |                       | No         |
-| `--weave-networking`         | Use Weave for networking (INCOMPLETE)                   | False                 | No         |
 | `--g5k-nb-nodes`             | Number of nodes to allocate                             | 3                     | No         |
 | `--g5k-walltime`             | Timelife of the machine                                 | "1:00:00"             | No         |
 | `--g5k-ssh-private-key`      | Path of your ssh private key                            | "~/.ssh/id_rsa"       | No         |
 | `--g5k-ssh-public-key`       | Path of your ssh public key                             | "< private-key >.pub" | No         |
 | `--g5k-image`                | Name of the image to deploy                             | "jessie-x64-min"      | No         |
 | `--g5k-resource-properties`  | Resource selection with OAR properties (SQL format)     |                       | No         |
+| `--swarm-discovery`          | Discovery service to use with Swarm                     | Generate a new token  | No         |
+| `--swarm-image`              | Specify Docker image to use for Swarm                   | "swarm:latest"        | No         |
+| `--swarm-strategy`           | Define a default scheduling strategy for Swarm          | "spread"              | No         |
+| `--swarm-opt`                | Define arbitrary flags for Swarm master                 |                       | No         |
+| `--swarm-join-opt`           | Define arbitrary flags for Swarm join                   |                       | No         |
+| `--weave-networking`         | Use Weave for networking (INCOMPLETE)                   | False                 | No         |
 
 #### Cluster deletion options
 
@@ -77,6 +77,15 @@ docker-g5k --g5k-username user \
 --g5k-password ******** \
 --g5k-site lille \
 create-cluster \
+--g5k-ssh-private-key ~/.ssh/g5k-key
+```
+
+An example where 3 nodes join an existing Docker Swarm cluster using a discovery token:
+```bash
+docker-g5k --g5k-username user \
+--g5k-password ******** \
+--g5k-site lille \
+create-cluster \
 --swarm-discovery "token://xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" \
 --g5k-ssh-private-key ~/.ssh/g5k-key
 ```
@@ -87,7 +96,6 @@ docker-g5k --g5k-username user \
 --g5k-password ******** \
 --g5k-site lille \
 create-cluster \
---swarm-discovery "token://xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" \
 --g5k-ssh-private-key ~/.ssh/g5k-key \
 --g5k-nb-nodes 16 \
 --g5k-resource-properties "cluster = 'chimint' and memnode > 8192 and cpucore >= 4"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # docker-g5k
-Docker Grid5000 client (CLI and Go library)
+A tool to create a Docker Swarm cluster for Docker Machine on Grid5000 testbed infrastructure.  
+It only support creating and deleting nodes in Docker Machine.   
 
 ## Requirements
 * [Docker](https://www.docker.com/products/overview#/install_the_platform)
@@ -52,7 +53,7 @@ Please follow the instructions from the [Grid5000 Wiki](https://www.grid5000.fr/
 | `--swarm-strategy`           | Define a default scheduling strategy for Swarm          | "spread"              | No         |
 | `--swarm-opt`                | Define arbitrary flags for Swarm master                 |                       | No         |
 | `--swarm-join-opt`           | Define arbitrary flags for Swarm join                   |                       | No         |
-| `--weave-networking`         | Use Weave for networking                                | False                 | No         |
+| `--weave-networking`         | Use Weave for networking (INCOMPLETE)                   | False                 | No         |
 | `--g5k-nb-nodes`             | Number of nodes to allocate                             | 3                     | No         |
 | `--g5k-walltime`             | Timelife of the machine                                 | "1:00:00"             | No         |
 | `--g5k-ssh-private-key`      | Path of your ssh private key                            | "~/.ssh/id_rsa"       | No         |
@@ -110,3 +111,13 @@ docker-g5k --g5k-username user \
 remove-cluster \
 --g5k-job-id 1234567
 ```
+
+#### Use
+
+After creating a cluster, you should be able to use it with usual Docker Machine commands.  
+By example, to list all nodes in the cluster :
+```bash
+docker-machine ls
+```
+ 
+**If you remove a node with Docker Machine 'rm' command, the job will be deleted and ALL nodes related to this job will become unavailable**  

--- a/README.md
+++ b/README.md
@@ -47,7 +47,12 @@ Please follow the instructions from the [Grid5000 Wiki](https://www.grid5000.fr/
 
 |            Option            |                       Description                       |     Default value     |  Required  |
 |------------------------------|---------------------------------------------------------|-----------------------|------------|
-| `--swarm-discovery-token`    | Discovery token to use for joining a Swarm cluster      |                       | Yes        |
+| `--swarm-discovery`          | Discovery service to use with Swarm                     |                       | Yes        |
+| `--swarm-image`              | Specify Docker image to use for Swarm                   | "swarm:latest"        | No         |
+| `--swarm-strategy`           | Define a default scheduling strategy for Swarm          | "spread"              | No         |
+| `--swarm-opt`                | Define arbitrary flags for Swarm master                 |                       | No         |
+| `--swarm-join-opt`           | Define arbitrary flags for Swarm join                   |                       | No         |
+| `--weave-networking`         | Use Weave for networking                                | False                 | No         |
 | `--g5k-nb-nodes`             | Number of nodes to allocate                             | 3                     | No         |
 | `--g5k-walltime`             | Timelife of the machine                                 | "1:00:00"             | No         |
 | `--g5k-ssh-private-key`      | Path of your ssh private key                            | "~/.ssh/id_rsa"       | No         |
@@ -71,6 +76,7 @@ docker-g5k --g5k-username user \
 --g5k-password ******** \
 --g5k-site lille \
 create-cluster \
+--swarm-discovery "token://xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" \
 --g5k-ssh-private-key ~/.ssh/g5k-key
 ```
 
@@ -80,6 +86,7 @@ docker-g5k --g5k-username user \
 --g5k-password ******** \
 --g5k-site lille \
 create-cluster \
+--swarm-discovery "token://xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" \
 --g5k-ssh-private-key ~/.ssh/g5k-key \
 --g5k-nb-nodes 16 \
 --g5k-resource-properties "cluster = 'chimint' and memnode > 8192 and cpucore >= 4"

--- a/README.md
+++ b/README.md
@@ -34,9 +34,9 @@ You need to be connected to the Grid5000 VPN to create and access your Docker no
 Do not forget to configure your DNS or use OpenVPN DNS auto-configuration.  
 Please follow the instructions from the [Grid5000 Wiki](https://www.grid5000.fr/mediawiki/index.php/VPN).
 
-### Driver-specific options
+### Command line flags
 
-#### Global options
+#### Global flags
 
 |            Option            |                       Description                       |     Default value     |  Required  |
 |------------------------------|---------------------------------------------------------|-----------------------|------------|
@@ -44,7 +44,7 @@ Please follow the instructions from the [Grid5000 Wiki](https://www.grid5000.fr/
 | `--g5k-password`             | Your Grid5000 account password                          |                       | Yes        |
 | `--g5k-site`                 | Site to reserve the resources on                        |                       | Yes        |
 
-#### Cluster creation options
+#### Cluster creation flags
 
 |            Option            |                       Description                       |     Default value     |  Required  |
 |------------------------------|---------------------------------------------------------|-----------------------|------------|
@@ -61,7 +61,7 @@ Please follow the instructions from the [Grid5000 Wiki](https://www.grid5000.fr/
 | `--swarm-join-opt`           | Define arbitrary flags for Swarm join                   |                       | No         |
 | `--weave-networking`         | Use Weave for networking (INCOMPLETE)                   | False                 | No         |
 
-#### Cluster deletion options
+#### Cluster deletion flags
 
 |            Option            |                       Description                       |     Default value     |  Required  |
 |------------------------------|---------------------------------------------------------|-----------------------|------------|

--- a/command/commands.go
+++ b/command/commands.go
@@ -1,0 +1,46 @@
+package command
+
+import (
+	"strconv"
+
+	"github.com/Spirals-Team/docker-machine-driver-g5k/api"
+)
+
+// Command struct contain all common informations used between commands
+type Command struct {
+	G5kAPI *api.Api
+
+	G5kJobID        int
+	G5kDeploymentID string
+
+	G5kUsername           string
+	G5kPassword           string
+	G5kSite               string
+	G5kWalltime           string
+	G5kSSHPrivateKeyPath  string
+	G5kSSHPublicKeyPath   string
+	G5kImage              string
+	G5kResourceProperties string
+	G5kNbNodes            int
+}
+
+// ParseArguments will parse command line arguments an set data in common struct (later)
+func (c *Command) ParseArguments(args []string) error {
+	// TODO: really parse arguments from cli
+	c.G5kImage = "jessie-x64-min"
+	c.G5kUsername = args[0]
+	c.G5kPassword = args[1]
+	c.G5kSite = args[2]
+	c.G5kWalltime = args[3]
+	c.G5kSSHPrivateKeyPath = args[4]
+	c.G5kSSHPublicKeyPath = args[4] + ".pub"
+
+	c.G5kAPI = api.NewApi(c.G5kUsername, c.G5kPassword, c.G5kSite, c.G5kImage)
+
+	var err error
+	if c.G5kNbNodes, err = strconv.Atoi(args[5]); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/command/commands.go
+++ b/command/commands.go
@@ -22,6 +22,8 @@ type Command struct {
 	G5kImage              string
 	G5kResourceProperties string
 	G5kNbNodes            int
+
+	SwarmDiscoveryToken string
 }
 
 // ParseArguments will parse command line arguments an set data in common struct (later)
@@ -37,8 +39,10 @@ func (c *Command) ParseArguments(args []string) error {
 
 	c.G5kAPI = api.NewApi(c.G5kUsername, c.G5kPassword, c.G5kSite, c.G5kImage)
 
+	c.SwarmDiscoveryToken = args[5]
+
 	var err error
-	if c.G5kNbNodes, err = strconv.Atoi(args[5]); err != nil {
+	if c.G5kNbNodes, err = strconv.Atoi(args[6]); err != nil {
 		return err
 	}
 

--- a/command/create_cluster.go
+++ b/command/create_cluster.go
@@ -90,10 +90,9 @@ func (c *Command) createHostAuthOptions(machineName string) *auth.Options {
 // createHostSwarmOptions returns a configured SwarmOptions for HostOptions struct
 func (c *Command) createHostSwarmOptions(machineName string, isMaster bool) *swarm.Options {
 	return &swarm.Options{
-		IsSwarm: true,
-		Image:   "swarm:latest",
-		// Agent:          !isMaster, to exclude Swarm master from Swarm Pool
-		Agent:          true,
+		IsSwarm:        true,
+		Image:          "swarm:latest",
+		Agent:          !isMaster, // exclude Swarm master from Swarm Pool
 		Master:         isMaster,
 		Discovery:      "token://" + c.cli.String("swarm-discovery-token"),
 		Address:        machineName,

--- a/command/create_cluster.go
+++ b/command/create_cluster.go
@@ -1,0 +1,200 @@
+package command
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+	"sync"
+
+	"github.com/docker/machine/commands/mcndirs"
+	"github.com/docker/machine/libmachine"
+	"github.com/docker/machine/libmachine/auth"
+	"github.com/docker/machine/libmachine/host"
+	"github.com/docker/machine/libmachine/log"
+
+	"github.com/Spirals-Team/docker-machine-driver-g5k/api"
+	"github.com/Spirals-Team/docker-machine-driver-g5k/driver"
+)
+
+// AllocateNodes allocate a new job with multiple nodes
+func (c *Command) AllocateNodes() error {
+	// convert walltime to seconds
+	seconds, err := api.ConvertDuration(c.G5kWalltime)
+	if err != nil {
+		return err
+	}
+
+	// create a new job request
+	jobReq := api.JobRequest{
+		Resources:  fmt.Sprintf("nodes=%v,walltime=%s", c.G5kNbNodes, c.G5kWalltime),
+		Command:    fmt.Sprintf("sleep %v", seconds),
+		Properties: c.G5kResourceProperties,
+		Types:      []string{"deploy"},
+	}
+
+	// submit job request
+	c.G5kJobID, err = c.G5kAPI.SubmitJob(jobReq)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// DeployNodes deploy the nodes in a job
+func (c *Command) DeployNodes() error {
+	// reading ssh public key file
+	pubkey, err := ioutil.ReadFile(c.G5kSSHPublicKeyPath)
+	if err != nil {
+		return err
+	}
+
+	// get job informations
+	job, err := c.G5kAPI.GetJob(c.G5kJobID)
+	if err != nil {
+		return err
+	}
+
+	// creating a new deployment request
+	deploymentReq := api.DeploymentRequest{
+		Nodes:       job.Nodes,
+		Environment: c.G5kImage,
+		Key:         string(pubkey),
+	}
+
+	// deploy environment
+	c.G5kDeploymentID, err = c.G5kAPI.SubmitDeployment(deploymentReq)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// createHostAuthOptions returns a configured AuthOptions for HostOptions struct
+func createHostAuthOptions(machineName string) *auth.Options {
+	return &auth.Options{
+		CertDir:          mcndirs.GetMachineCertDir(),
+		CaCertPath:       filepath.Join(mcndirs.GetMachineCertDir(), "ca.pem"),
+		CaPrivateKeyPath: filepath.Join(mcndirs.GetMachineCertDir(), "ca-key.pem"),
+		ClientCertPath:   filepath.Join(mcndirs.GetMachineCertDir(), "cert.pem"),
+		ClientKeyPath:    filepath.Join(mcndirs.GetMachineCertDir(), "key.pem"),
+		ServerCertPath:   filepath.Join(mcndirs.GetMachineDir(), machineName, "server.pem"),
+		ServerKeyPath:    filepath.Join(mcndirs.GetMachineDir(), machineName, "server-key.pem"),
+		StorePath:        filepath.Join(mcndirs.GetMachineDir(), machineName),
+		ServerCertSANs:   nil,
+	}
+}
+
+func (c *Command) provisionNode(nodeName string) error {
+	// create a new libmachine client
+	client := libmachine.NewClient(mcndirs.GetBaseDir(), mcndirs.GetMachineCertDir())
+	defer client.Close()
+
+	// create driver instance for libmachine
+	driver := driver.NewDriver()
+
+	// set g5k driver parameters
+	driver.G5kImage = c.G5kImage
+	driver.G5kUsername = c.G5kUsername
+	driver.G5kPassword = c.G5kPassword
+	driver.G5kSite = c.G5kSite
+	driver.G5kWalltime = c.G5kWalltime
+	driver.G5kSSHPrivateKeyPath = c.G5kSSHPrivateKeyPath
+	driver.G5kSSHPublicKeyPath = c.G5kSSHPublicKeyPath
+	driver.G5kHostToProvision = nodeName
+	driver.G5kJobID = c.G5kJobID
+
+	// set base driver parameters
+	driver.BaseDriver.MachineName = nodeName
+	driver.BaseDriver.StorePath = mcndirs.GetBaseDir()
+	driver.BaseDriver.SSHKeyPath = driver.GetSSHKeyPath()
+
+	// marshal configured driver
+	data, err := json.Marshal(driver)
+	if err != nil {
+		return err
+	}
+
+	// create a new host config
+	h, err := client.NewHost("g5k", data)
+	if err != nil {
+		return err
+	}
+
+	// mandatory, or driver will use bad paths
+	h.HostOptions.AuthOptions = createHostAuthOptions(nodeName)
+
+	// provision the new machine
+	if err := client.Create(h); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// ProvisionNodes provision the nodes
+func (c *Command) ProvisionNodes() error {
+	// get deployment informations
+	deployment, err := c.G5kAPI.GetDeployment(c.G5kDeploymentID)
+	if err != nil {
+		return err
+	}
+
+	// provision all deployed nodes
+	var wg sync.WaitGroup
+	for _, v := range deployment.Nodes {
+		wg.Add(1)
+		go func(nodeName string) {
+			defer wg.Done()
+			c.provisionNode(nodeName)
+		}(v)
+	}
+
+	// wait nodes provisionning to finish
+	wg.Wait()
+
+	return nil
+}
+
+// CreateCluster create nodes in docker-machine
+func (c *Command) CreateCluster() error {
+	// create a new libmachine client
+	client := libmachine.NewClient(mcndirs.GetBaseDir(), mcndirs.GetMachineCertDir())
+	defer client.Close()
+
+	// submit new job
+	if err := c.AllocateNodes(); err != nil {
+		return err
+	}
+
+	// wait until job is running
+	c.G5kAPI.WaitUntilJobIsReady(c.G5kJobID)
+
+	// submit new deployment
+	if err := c.DeployNodes(); err != nil {
+		return err
+	}
+
+	// wait until deployment is finished
+	c.G5kAPI.WaitUntilDeploymentIsFinished(c.G5kDeploymentID)
+
+	// provision nodes
+	if err := c.ProvisionNodes(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// printHostConfig print the json config of a Host (used for debug)
+func printHostConfig(h *host.Host) {
+	host, err := json.Marshal(h)
+	if err != nil {
+		log.Error(err)
+		return
+	}
+
+	fmt.Println(string(host))
+}

--- a/command/list_cluster.go
+++ b/command/list_cluster.go
@@ -1,0 +1,1 @@
+package command

--- a/command/remove_cluster.go
+++ b/command/remove_cluster.go
@@ -1,0 +1,1 @@
+package command

--- a/command/remove_cluster.go
+++ b/command/remove_cluster.go
@@ -35,6 +35,14 @@ func (c *Command) RemoveCluster() error {
 				log.Errorf("Cannot remove node '%s' : %s", h.Name, err)
 			}
 
+			// filter the nodes to remove on their job ID
+			if jobID := c.cli.Int("g5k-job-id"); jobID != -1 {
+				// skip nodes with different job ID than provided
+				if driverConfig.G5kJobID != jobID {
+					continue
+				}
+			}
+
 			// check the job is already in the list of deleted jobs
 			if _, exist := jobs[driverConfig.G5kJobID]; !exist {
 				// send API call to kill job

--- a/command/remove_cluster.go
+++ b/command/remove_cluster.go
@@ -1,1 +1,29 @@
 package command
+
+import (
+	"github.com/docker/machine/commands/mcndirs"
+	"github.com/docker/machine/libmachine"
+	"github.com/docker/machine/libmachine/persist"
+)
+
+// RemoveCluster remove all nodes
+func (c *Command) RemoveCluster() error {
+	// create a new libmachine client
+	client := libmachine.NewClient(mcndirs.GetBaseDir(), mcndirs.GetMachineCertDir())
+	defer client.Close()
+
+	// load hosts from libmachine storage
+	lst, _, err := persist.LoadAllHosts(client)
+	if err != nil {
+		return err
+	}
+
+	// TODO: Kill Grid5000 job
+
+	// remove hosts from libmachine storage
+	for _, v := range lst {
+		client.Remove(v.Name)
+	}
+
+	return nil
+}

--- a/command/remove_cluster.go
+++ b/command/remove_cluster.go
@@ -1,9 +1,14 @@
 package command
 
 import (
+	"encoding/json"
+
 	"github.com/docker/machine/commands/mcndirs"
 	"github.com/docker/machine/libmachine"
+	"github.com/docker/machine/libmachine/log"
 	"github.com/docker/machine/libmachine/persist"
+
+	"github.com/Spirals-Team/docker-machine-driver-g5k/driver"
 )
 
 // RemoveCluster remove all nodes
@@ -18,12 +23,46 @@ func (c *Command) RemoveCluster() error {
 		return err
 	}
 
-	// TODO: Kill Grid5000 job
+	// store already deleted jobs to minimize API calls
+	jobs := make(map[int]bool)
 
 	// remove hosts from libmachine storage
-	for _, v := range lst {
-		client.Remove(v.Name)
+	for _, h := range lst {
+		// only remove Grid5000 nodes
+		if h.DriverName == "g5k" {
+			driverConfig, err := getG5kDriverConfig(h.RawDriver)
+			if err != nil {
+				log.Errorf("Cannot remove node '%s' : %s", h.Name, err)
+			}
+
+			// check the job is already in the list of deleted jobs
+			if _, exist := jobs[driverConfig.G5kJobID]; !exist {
+				// send API call to kill job
+				c.api.KillJob(driverConfig.G5kJobID)
+
+				// add job ID to list of deleted jobs
+				jobs[driverConfig.G5kJobID] = true
+
+				log.Infof("Job '%v' killed", driverConfig.G5kJobID)
+			}
+
+			// remove node from libmachine storage
+			client.Remove(h.Name)
+
+			log.Infof("Node '%s' removed", h.Name)
+		}
 	}
 
 	return nil
+}
+
+// getG5kDriverConfig takes a raw driver and return a configured Driver structure
+func getG5kDriverConfig(rawDriver []byte) (*driver.Driver, error) {
+	// unmarshal driver configuration
+	var drv driver.Driver
+	if err := json.Unmarshal(rawDriver, &drv); err != nil {
+		return nil, err
+	}
+
+	return &drv, nil
 }

--- a/main.go
+++ b/main.go
@@ -22,6 +22,8 @@ func main() {
 	switch os.Args[1] {
 	case "create-cluster":
 		cmd.CreateCluster()
+	case "remove-cluster":
+		cmd.RemoveCluster()
 	default:
 		usage()
 	}

--- a/main.go
+++ b/main.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/Spirals-Team/docker-g5k/command"
+)
+
+func usage() {
+	fmt.Println("Usage:")
+	fmt.Println("	create-cluster <g5k-user> <g5k-password> <g5k-site> <g5k-walltime> <path to ssh private key> <nb nodes>")
+	os.Exit(1)
+}
+
+func main() {
+	cmd := &command.Command{}
+	if err := cmd.ParseArguments(os.Args[2:]); err != nil {
+		panic(err)
+	}
+
+	switch os.Args[1] {
+	case "create-cluster":
+		cmd.CreateCluster()
+	default:
+		usage()
+	}
+}

--- a/main.go
+++ b/main.go
@@ -1,30 +1,108 @@
 package main
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/Spirals-Team/docker-g5k/command"
+	"github.com/codegangsta/cli"
+	"github.com/docker/machine/libmachine/log"
+	"github.com/docker/machine/libmachine/mcnutils"
 )
 
-func usage() {
-	fmt.Println("Usage:")
-	fmt.Println("	create-cluster <g5k-user> <g5k-password> <g5k-site> <g5k-walltime> <path to ssh private key> <swarm discovery token> <nb nodes>")
-	os.Exit(1)
-}
+var (
+	// AppFlags stores cli flags for common parameters
+	AppFlags = []cli.Flag{
+		cli.StringFlag{
+			Name:  "g5k-username",
+			Usage: "Your Grid5000 account username",
+			Value: "",
+		},
 
-func main() {
-	cmd := &command.Command{}
-	if err := cmd.ParseArguments(os.Args[2:]); err != nil {
-		panic(err)
+		cli.StringFlag{
+			Name:  "g5k-password",
+			Usage: "Your Grid5000 account password",
+			Value: "",
+		},
+
+		cli.StringFlag{
+			Name:  "g5k-site",
+			Usage: "Site to reserve the resources on",
+			Value: "",
+		},
 	}
 
-	switch os.Args[1] {
-	case "create-cluster":
-		cmd.CreateCluster()
-	case "remove-cluster":
-		cmd.RemoveCluster()
-	default:
-		usage()
+	// CliCommands stores cli commands and their flags
+	CliCommands = []cli.Command{
+		{
+			Name:   "create-cluster",
+			Usage:  "Create a new Docker Swarm cluster on Grid5000",
+			Action: command.RunCreateClusterCommand,
+			Flags: []cli.Flag{
+				cli.StringFlag{
+					Name:  "g5k-walltime",
+					Usage: "Machine's lifetime (HH:MM:SS)",
+					Value: "1:00:00",
+				},
+
+				cli.StringFlag{
+					Name:  "g5k-ssh-private-key",
+					Usage: "Path of your ssh private key",
+					Value: mcnutils.GetHomeDir() + "/.ssh/id_rsa",
+				},
+
+				cli.StringFlag{
+					Name:  "g5k-ssh-public-key",
+					Usage: "Path of your ssh public key",
+					Value: "",
+				},
+
+				cli.StringFlag{
+					Name:  "g5k-image",
+					Usage: "Name of the image to deploy",
+					Value: "jessie-x64-min",
+				},
+
+				cli.StringFlag{
+					Name:  "g5k-resource-properties",
+					Usage: "Resource selection with OAR properties (SQL format)",
+					Value: "",
+				},
+
+				cli.IntFlag{
+					Name:  "g5k-nb-nodes",
+					Usage: "Number of nodes to allocate",
+					Value: 3,
+				},
+
+				cli.StringFlag{
+					Name:  "swarm-discovery-token",
+					Usage: "Discovery token to use for joining a Swarm cluster",
+					Value: "",
+				},
+			},
+		},
+		{
+			Name:   "remove-cluster",
+			Usage:  "Remove a Docker Swarm cluster from Grid5000",
+			Action: command.RunRemoveClusterCommand,
+			Flags: []cli.Flag{
+				cli.IntFlag{
+					Name:  "g5k-job-id",
+					Usage: "Only remove nodes related to the provided job ID (By default ALL nodes from ALL jobs will be removed)",
+					Value: -1,
+				},
+			},
+		},
+	}
+)
+
+func main() {
+	app := cli.NewApp()
+
+	app.Flags = AppFlags
+	app.Commands = CliCommands
+
+	if err := app.Run(os.Args); err != nil {
+		log.Error(err)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -75,9 +75,38 @@ var (
 				},
 
 				cli.StringFlag{
-					Name:  "swarm-discovery-token",
-					Usage: "Discovery token to use for joining a Swarm cluster",
+					Name:  "swarm-discovery",
+					Usage: "Discovery service to use with Swarm",
 					Value: "",
+				},
+
+				cli.StringFlag{
+					Name:  "swarm-image",
+					Usage: "Specify Docker image to use for Swarm",
+					Value: "swarm:latest",
+				},
+
+				cli.StringFlag{
+					Name:  "swarm-strategy",
+					Usage: "Define a default scheduling strategy for Swarm",
+					Value: "spread",
+				},
+
+				cli.StringSliceFlag{
+					Name:  "swarm-opt",
+					Usage: "Define arbitrary flags for Swarm master",
+					Value: nil,
+				},
+
+				cli.StringSliceFlag{
+					Name:  "swarm-join-opt",
+					Usage: "Define arbitrary flags for Swarm join",
+					Value: nil,
+				},
+
+				cli.BoolFlag{
+					Name:  "weave-networking",
+					Usage: "Use Weave for networking",
 				},
 			},
 		},

--- a/main.go
+++ b/main.go
@@ -9,7 +9,7 @@ import (
 
 func usage() {
 	fmt.Println("Usage:")
-	fmt.Println("	create-cluster <g5k-user> <g5k-password> <g5k-site> <g5k-walltime> <path to ssh private key> <nb nodes>")
+	fmt.Println("	create-cluster <g5k-user> <g5k-password> <g5k-site> <g5k-walltime> <path to ssh private key> <swarm discovery token> <nb nodes>")
 	os.Exit(1)
 }
 


### PR DESCRIPTION
PR overview:

- Add Travis CI configuration ;
- Add 'create-cluster' command to create a Docker Swarm cluster on Grid5000 in Docker Machine (flags are the same as docker-machine-driver-g5k) ;
- Add 'remove-cluster' command to kill job(s) and remove machines from Docker Machine (a filter on job ID is possible) ;
- Add support for Weave networking (Incomplete for now, the deployment needs to be done manually)
- Update README : Add installation from sources procedure, flags description and usage examples.
