### PR TITLE
Improve Weave support, add new cli flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Please follow the instructions from the [Grid5000 Wiki](https://www.grid5000.fr/
 | `--swarm-strategy`           | Define a default scheduling strategy for Swarm          | "spread"              | No         |
 | `--swarm-opt`                | Define arbitrary flags for Swarm master                 |                       | No         |
 | `--swarm-join-opt`           | Define arbitrary flags for Swarm join                   |                       | No         |
+| `--swarm-master-join`        | Make Swarm master join the Swarm pool                   | False                 | No         |
 | `--weave-networking`         | Use Weave for networking                                | False                 | No         |
 
 #### Cluster deletion flags

--- a/README.md
+++ b/README.md
@@ -130,6 +130,4 @@ Then run a container using Weave networking:
 docker run --net=weave -h foo.weave.local --name foo $(~/.docker/machine/weave-net dns-args) -td your-image:version
 ```
 Your containers can now communicate with each other using theirs short ('foo') or long ('foo.weave.local') name.  
-The name used NEED to be the one given in parameter '-h'. The name of the container (parameter '--name') is not used by Weave.  
-
-If you need to use the Weave Net script, it is located in '~/.docker/machine/weave-net'.
+The name used NEED to be the one given in parameter '-h'. The name of the container (parameter '--name') is not used by Weave.

--- a/command/create_cluster.go
+++ b/command/create_cluster.go
@@ -93,10 +93,16 @@ func (c *Command) createHostAuthOptions(machineName string) *auth.Options {
 
 // createHostSwarmOptions returns a configured SwarmOptions for HostOptions struct
 func (c *Command) createHostSwarmOptions(machineName string, isMaster bool) *swarm.Options {
+	runAgent := true
+	// By default, exclude master node from Swarm pool, but can be overrided by swarm-master-join flag
+	if isMaster && !c.cli.Bool("swarm-master-join") {
+		runAgent = false
+	}
+
 	return &swarm.Options{
 		IsSwarm:            true,
 		Image:              c.cli.String("swarm-image"),
-		Agent:              !isMaster, // exclude Swarm master from Swarm Pool
+		Agent:              runAgent,
 		Master:             isMaster,
 		Discovery:          c.cli.String("swarm-discovery"),
 		Address:            machineName,

--- a/libdockerg5k/weave/weave.go
+++ b/libdockerg5k/weave/weave.go
@@ -1,130 +1,46 @@
 package weave
 
+/*
+Procedure to deploy Weave Net and Discovery:
+
+Net:
+docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v /proc:/hostproc -e PROCFS=/hostproc --privileged --net=host weaveworks/weaveexec --local launch-router
+docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v /proc:/hostproc -e PROCFS=/hostproc --privileged --net=host weaveworks/weaveexec --local launch-plugin
+
+Discovery:
+docker run -d --name weavediscovery --net=host weaveworks/weavediscovery $SWARM_DISCOVERY
+
+Run containers with:
+docker run --net=weave -h barbar.weave.local --dns=172.17.0.1 --dns-search=weave.local. -ti alpine:latest /bin/sh
+*/
+
 import (
 	"fmt"
-	"io"
-	"net/http"
-	"os"
-	"os/exec"
 
-	"github.com/docker/machine/commands/mcndirs"
 	"github.com/docker/machine/libmachine/host"
 )
 
-const (
-	weaveNetURL       = "https://git.io/weave"
-	weaveDiscoveryURL = "https://raw.githubusercontent.com/weaveworks/discovery/master/discovery"
-)
-
-var (
-	weaveNetPath       = mcndirs.GetBaseDir() + "/weave-net"
-	weaveDiscoveryPath = mcndirs.GetBaseDir() + "/weave-discovery"
-)
-
-// downloadFile download a script from a given URL and store it to the provided path (It will Replace/Create the file and chmod 755)
-func downloadScript(url, path string) error {
-	// create new file (create/replace file, and chmod 755)
-	out, err := os.OpenFile(path, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0755)
-	if err != nil {
-		return err
-	}
-	defer out.Close()
-
-	// download script
-	resp, err := http.Get(url)
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-
-	// put downloaded data to a file
-	if _, err := io.Copy(out, resp.Body); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-// InstallLocalWeaveNetScript download the Weave Net script to the local Docker Machine base directory
-func InstallLocalWeaveNetScript() error {
-	// download script
-	if err := downloadScript(weaveNetURL, weaveNetPath); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-// InstallLocalWeaveDiscoveryScript download the Weave Discovery script to the local Docker Machine base directory
-func InstallLocalWeaveDiscoveryScript() error {
-	// download script
-	if err := downloadScript(weaveDiscoveryURL, weaveDiscoveryPath); err != nil {
-		return err
-	}
-
-	return nil
-}
-
 // RunWeaveNet run Weave Net on given host
 func RunWeaveNet(h *host.Host) error {
-	// execute "weave launch"
-	cmd := exec.Command(weaveNetPath, "launch", "--http-addr=0.0.0.0:6784")
-
-	// get Docker engine URL for remote host
-	url, err := h.URL()
-	if err != nil {
+	// Launch Weave Net Router
+	if _, err := h.RunSSHCommand("docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v /proc:/hostproc -e PROCFS=/hostproc --privileged --net=host weaveworks/weaveexec --local launch-router"); err != nil {
 		return err
 	}
 
-	// configure Docker env variables
-	cmd.Env = []string{
-		"DOCKER_TLS_VERIFY=1",
-		fmt.Sprintf("DOCKER_HOST=%s", url),
-		fmt.Sprintf("DOCKER_CERT_PATH=%s", h.AuthOptions().StorePath),
-	}
-
-	// execute command
-	err = cmd.Start()
-	if err != nil {
+	// Launch Weave Net network plugin
+	if _, err := h.RunSSHCommand("docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v /proc:/hostproc -e PROCFS=/hostproc --privileged --net=host weaveworks/weaveexec --local launch-plugin"); err != nil {
 		return err
 	}
-
-	// wait command to finish
-	cmd.Wait()
 
 	return nil
 }
 
 // RunWeaveDiscovery run Weave Discovery on a host using the given Swarm Discovery method
 func RunWeaveDiscovery(h *host.Host, swarmDiscovery string) error {
-	// create command "discovery join --discovered-port=6783 --advertise-router $SWARM_DISCOVERY_METHOD"
-	cmd := exec.Command(weaveDiscoveryPath, "join", "--discovered-port=6783", "--advertise-router", swarmDiscovery)
-
-	// get Docker engine URL for remote host
-	url, err := h.URL()
-	if err != nil {
+	// Launch Weave Discovery
+	if _, err := h.RunSSHCommand(fmt.Sprintf("docker run -d --name weavediscovery --net=host weaveworks/weavediscovery %s", swarmDiscovery)); err != nil {
 		return err
 	}
-
-	// configure Docker and Weave discovery env variables
-	cmd.Env = []string{
-		// Weave discovery
-		"IMAGE_VERSION=latest",
-
-		// Docker
-		"DOCKER_TLS_VERIFY=1",
-		fmt.Sprintf("DOCKER_HOST=%s", url),
-		fmt.Sprintf("DOCKER_CERT_PATH=%s", h.AuthOptions().StorePath),
-	}
-
-	// execute command
-	err = cmd.Start()
-	if err != nil {
-		return err
-	}
-
-	// wait command to finish
-	cmd.Wait()
 
 	return nil
 }

--- a/main.go
+++ b/main.go
@@ -105,6 +105,11 @@ var (
 				},
 
 				cli.BoolFlag{
+					Name:  "swarm-master-join",
+					Usage: "Make Swarm master join the Swarm pool",
+				},
+
+				cli.BoolFlag{
 					Name:  "weave-networking",
 					Usage: "Use Weave for networking",
 				},


### PR DESCRIPTION
PR overview:

- Remove usage of Weave scripts to deploy Weave Net and Discovery. The Weave scripts are not downloaded on the client machine anymore ;
- Deploy Weave Net and Discovery from their Docker images directly on the nodes ;
- Add command line flag to make Swarm master join the Swarm pool (by default Swarm master is excluded) ;
- Update README.