### PR TITLE
Fix Weave Networking

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,11 @@ A tool to create a Docker Swarm cluster for Docker Machine on the Grid5000 testb
 
 You need a Grid5000 account to use this tool. See [this page](https://www.grid5000.fr/mediawiki/index.php/Grid5000:Get_an_account) to create an account.
 
+## VPN
+**You need to be connected to the Grid5000 VPN to create and access your Docker nodes.**  
+**Do not forget to configure your DNS or use OpenVPN DNS auto-configuration.**  
+**Please follow the instructions from the [Grid5000 Wiki](https://www.grid5000.fr/mediawiki/index.php/VPN).**
+
 ## Installation
 
 ## Installation from GitHub releases
@@ -39,11 +44,6 @@ export PATH=$PATH:$GOPATH/bin
 ```
 
 ## How to use
-
-### VPN
-You need to be connected to the Grid5000 VPN to create and access your Docker nodes.  
-Do not forget to configure your DNS or use OpenVPN DNS auto-configuration.  
-Please follow the instructions from the [Grid5000 Wiki](https://www.grid5000.fr/mediawiki/index.php/VPN).
 
 ### Command line flags
 Flags marked with `[ ]` can be given multiple times and the values will be added.

--- a/command/create_cluster.go
+++ b/command/create_cluster.go
@@ -418,7 +418,9 @@ func (c *CreateClusterCommand) provisionNodes(deployedNodes *map[string]node.Nod
 		log.Infof("Swarm bootstrap node is '%s' ('%s')", bootstrapNode.MachineName, bootstrapNode.NodeName)
 
 		// provision the node
-		bootstrapNode.ProvisionNode()
+		if err := bootstrapNode.ProvisionNode(); err != nil {
+			fmt.Printf("Error while provisionning bootstrap node '%s' ('%s'): '%s'\n", bootstrapNode.NodeName, bootstrapNode.MachineName, err)
+		}
 
 		// remove the node from the list
 		delete(*deployedNodes, k)
@@ -432,7 +434,9 @@ func (c *CreateClusterCommand) provisionNodes(deployedNodes *map[string]node.Nod
 		wg.Add(1)
 		go func(n node.Node) {
 			defer wg.Done()
-			n.ProvisionNode()
+			if err := n.ProvisionNode(); err != nil {
+				fmt.Printf("Error while provisionning node '%s' ('%s'): '%s'\n", n.NodeName, n.MachineName, err)
+			}
 		}(n)
 	}
 

--- a/libdockerg5k/weave/weave.go
+++ b/libdockerg5k/weave/weave.go
@@ -4,8 +4,7 @@ package weave
 Procedure to deploy Weave Net and Discovery:
 
 Net:
-docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v /proc:/hostproc -e PROCFS=/hostproc --privileged --net=host weaveworks/weaveexec --local launch-router
-docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v /proc:/hostproc -e PROCFS=/hostproc --privileged --net=host weaveworks/weaveexec --local launch-plugin
+docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v /proc:/hostproc -e PROCFS=/hostproc --privileged --net=host weaveworks/weaveexec --local launch-router --plugin
 
 Discovery:
 docker run -d --name weavediscovery --net=host weaveworks/weavediscovery $SWARM_DISCOVERY
@@ -22,14 +21,9 @@ import (
 
 // RunWeaveNet run Weave Net on given host
 func RunWeaveNet(h *host.Host) error {
-	// Launch Weave Net Router
-	if _, err := h.RunSSHCommand("docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v /proc:/hostproc -e PROCFS=/hostproc --privileged --net=host weaveworks/weaveexec --local launch-router"); err != nil {
-		return err
-	}
-
-	// Launch Weave Net network plugin
-	if _, err := h.RunSSHCommand("docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v /proc:/hostproc -e PROCFS=/hostproc --privileged --net=host weaveworks/weaveexec --local launch-plugin"); err != nil {
-		return err
+	// Run Weave Net router with Docker plugin
+	if _, err := h.RunSSHCommand("docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -v /proc:/hostproc -e PROCFS=/hostproc --privileged --net=host weaveworks/weaveexec --local launch-router --plugin"); err != nil {
+		return fmt.Errorf("Weave Net run command failed: '%s'", err)
 	}
 
 	return nil
@@ -37,9 +31,9 @@ func RunWeaveNet(h *host.Host) error {
 
 // RunWeaveDiscovery run Weave Discovery on a host using the given Swarm Discovery method
 func RunWeaveDiscovery(h *host.Host, swarmDiscovery string) error {
-	// Launch Weave Discovery
+	// Run Weave Discovery
 	if _, err := h.RunSSHCommand(fmt.Sprintf("docker run -d --name weavediscovery --net=host weaveworks/weavediscovery %s", swarmDiscovery)); err != nil {
-		return err
+		return fmt.Errorf("Weave Discovery run command failed: '%s'", err)
 	}
 
 	return nil


### PR DESCRIPTION
PR overview:

- Fix Weave Networking provisioning. The "launch-plugin" command does not exist anymore, it is replaced by the flag "--plugin" of the "launch-router" command ;
- Moving VPN requirement at the top of the README.

Close #8 